### PR TITLE
refactor: replace Deno emit with esbuild for bundling

### DIFF
--- a/builder.ts
+++ b/builder.ts
@@ -1,10 +1,23 @@
-import { bundle } from "./deps.ts";
+import * as esbuild from "esbuild-wasm";
+import { denoPlugins } from "@luca/esbuild-deno-loader";
 import { metablock } from "./src/metablock.ts";
+
 const url = new URL("./src/scriptbody.ts", import.meta.url);
 
-const bundled = await bundle(url, { importMap: "./deno.jsonc" });
-const script = `${metablock}\n\n${bundled.code}`;
+await esbuild.initialize({});
+const result = await esbuild.build({
+  bundle: true,
+  outdir: "./out",
+  entryPoints: [url.toString()],
+  write: false,
+  plugins: [...denoPlugins()],
+  target: "esnext",
+  platform: "browser",
+  format: "esm",
+});
 
+const script = `${metablock}\n\n${result.outputFiles[0].text}`;
+esbuild.stop();
 async function isExist(
   path: string,
 ): Promise<{ isExist: false } | { isExist: true; isDirectory: boolean }> {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,6 +4,8 @@
     "build": "deno run --allow-read --allow-write --allow-env --allow-net --allow-run builder.ts"
   },
   "imports": {
-    "@violentmonkey/types": "https://esm.sh/v135/@violentmonkey/types@0.1.7/index.d.ts"
+    "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
+    "@violentmonkey/types": "npm:@violentmonkey/types@^0.2.1",
+    "esbuild-wasm": "npm:esbuild-wasm@^0.25.2"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,0 @@
-export { bundle } from "jsr:@deno/emit@^0.40.3";


### PR DESCRIPTION
- Switched from using Deno's emit API to esbuild for script bundling.
- Integrated esbuild-wasm and @luca/esbuild-deno-loader for compatibility.
- Updated deno.jsonc to include necessary imports for esbuild.
- Removed unused deps.ts file as it is no longer required.
- Ensured the output script includes the metablock and adheres to esbuild configurations.
