### PR TITLE
Fix transition for detecting compose URL from MONITORING_SEARCH_PAGE instead of OBSERVING_TWITTER_PAGE

### DIFF
--- a/src/scriptbody.ts
+++ b/src/scriptbody.ts
@@ -238,7 +238,7 @@ const transitions: Transition<StateContext>[] = [
     execute: disconnectSearchTimeline,
   },
   {
-    from: "OBSERVING_TWITTER_PAGE",
+    from: "MONITORING_SEARCH_PAGE",
     event: "DETECT_COMPOSE_URL",
     to: "LOADING_COMPOSE_PAGE",
     condition: (event) => {


### PR DESCRIPTION
This change updates the transition for the DETECT_COMPOSE_URL event to correctly
originate from the MONITORING_SEARCH_PAGE state instead of OBSERVING_TWITTER_PAGE.

The DETECT_COMPOSE_URL event logically occurs when monitoring the search page (MONITORING_SEARCH_PAGE),
 not while observing the general Twitter page (OBSERVING_TWITTER_PAGE).
This fix ensures that the state transitions are consistent with the application's behavior and logic.

Improves the accuracy of state transitions.
Prevents unintended transitions from OBSERVING_TWITTER_PAGE to LOADING_COMPOSE_PAGE.
No adverse effects on other states or events.
