### PR TITLE
Remove GM_setClipboard and related grants in favor of navigator.clipboard

### DIFF
--- a/src/metablock.ts
+++ b/src/metablock.ts
@@ -7,10 +7,5 @@ export const metablock = `// ==UserScript==
 // @match        https://twitter.com/*
 // @match        https://x.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=twitter.com
-// @grant        GM_setClipboard
-// @grant        GM_registerMenuCommand
-// @grant        GM_unregisterMenuCommand
-// @grant        GM_setValue
-// @grant        GM_getValue
 // ==/UserScript==
 `;

--- a/src/scriptbody.ts
+++ b/src/scriptbody.ts
@@ -61,15 +61,14 @@ const setupComposePage: ExecuteHandler<StateContext> = (event, context) => {
   if (event.type !== "COMPOSE_PAGE_LOADED") return;
   const composeButton = document.querySelector(event.css_selector)!;
   const text = getTweetText(context.tweet);
-  GM_registerMenuCommand("copy to clipboard", () => {
-    GM_setClipboard(text, "text");
-  });
   const unsetButton = composeButton.parentElement!;
   const div = document.createElement("div");
   div.addEventListener("click", (target) => {
     const currentTarget = target.currentTarget;
     if (currentTarget instanceof HTMLDivElement) {
-      GM_setClipboard(text, "text");
+      navigator.clipboard.writeText(text).then(() =>
+        console.log("Text copied!")
+      ).catch((err) => console.error("Clipboard write failed", err));
     }
   });
 


### PR DESCRIPTION
This commit removes the dependency on Greasemonkey-specific
clipboard functions (`GM_setClipboard`) and replaces them
with the standard Web API `navigator.clipboard.writeText`.

Additionally, the related grants (`GM_setClipboard`, `GM_registerMenuCommand`, etc.)
have been removed from the metablock.
